### PR TITLE
abort install script on linux distro without apt-get package manager

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -103,8 +103,6 @@ function run_installer()
 		done
 	}
 
-
-
 	function exe() {
 		echo "\$ $@"; "$@"
 	}
@@ -390,6 +388,7 @@ function run_installer()
 		else
 			uncheck "apt-get is missing"
 			isApt=false
+			abortInstall "${red}==>${reset} ${b}OS not supported:${reset} geth one-liner currently support OS X, Ubuntu and Debian.\nFor instructions on installing ethereum on other platforms please visit ${u}${blue}http://ethereum.org/${reset}"
 		fi
 	}
 
@@ -449,7 +448,7 @@ function run_installer()
 	{
 		echo
 		error "Installation failed"
-		echo "$1"
+		echo -e "$1"
 		echo
 		exit 0
 	}


### PR DESCRIPTION
When the `install.sh` script is run on a linux distro without the apt-get package manager the script doesn't stop and print an appropiate message to the user. This PR will abort the script and inform the user that he is on an unsupported platform. It also enables backslash interpretation for the echo command to interpret newlines in the abortInstall function.