### PR TITLE
-q is not an option of add-apt-repository

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -409,8 +409,8 @@ function run_installer()
 		fi
 
 		info "Adding ethereum repository"
-		exe sudo add-apt-repository -q -y ppa:ethereum/ethereum
-		exe sudo add-apt-repository -q -y ppa:ethereum/ethereum-dev
+		exe sudo add-apt-repository -y ppa:ethereum/ethereum
+		exe sudo add-apt-repository -y ppa:ethereum/ethereum-dev
 		echo
 
 		info "Updating packages"


### PR DESCRIPTION
Looked at versions 0.82.7.5, 0.92.36, and 0.96.8 of software-properties
(This is equivalent to what Ubuntu precise, trusty, utopic, and wily provides. Or basically "any version of Ubuntu".)
http://packages.ubuntu.com/wily/software-properties-common
There has never been a -q option to add-apt-repository. So this was definitely an error.