### PR TITLE
Provide default value in Linux install prompt

### DIFF
--- a/bin/install-cpp.sh
+++ b/bin/install-cpp.sh
@@ -100,7 +100,7 @@ function run_installer()
 				[yY] ) echo; break ;;
 				'' ) echo; break ;;
 				[nN] ) abortInstall "${red}==>${reset} Process stopped by user. To resume the install run the one-liner command again." ;;
-				* ) abortInstall "${red}==>${reset} Process stopped by user. To resume the install run the one-liner command again." ;;
+				* ) echo "Unrecognized option provided. Please provide either 'Y' or 'N'";
 			esac
 		done
 	}

--- a/bin/install-cpp.sh
+++ b/bin/install-cpp.sh
@@ -95,9 +95,11 @@ function run_installer()
 	function wait_for_user() {
 		while :
 		do
-			read -p "${blue}==>${reset} $1 (Y/n) " imp
+			read -p "${blue}==>${reset} $1 [Y/n] " imp
 			case $imp in
 				[yY] ) echo; break ;;
+				'' ) echo; break ;;
+				[nN] ) abortInstall "${red}==>${reset} Process stopped by user. To resume the install run the one-liner command again." ;;
 				* ) abortInstall "${red}==>${reset} Process stopped by user. To resume the install run the one-liner command again." ;;
 			esac
 		done


### PR DESCRIPTION
In most Unix scripts when you are queried with a [Y/n] it is
always interpreted that the capitalized option is the default
(chosen by simply pressing Enter).

So we are adding Yes as the default option.