### PR TITLE
general cleanup of href links in .md files, as well as in jade recipes

### DIFF
--- a/views/cli.jade
+++ b/views/cli.jade
@@ -32,7 +32,7 @@ block content
     div.container
       div.row
         div.col-md-12
-          include:md content/geth.md
+          include:md content/cli.md
 
   div.main-tutorial.hidden.even
     div.container

--- a/views/content/cli.md
+++ b/views/content/cli.md
@@ -18,7 +18,7 @@ If you are building a business that needs to have always on connections to the e
 
 ## Geth
 
-![Logo for C++](/images/icons/gopher.png)
+![Logo for Go](/images/icons/gopher.png)
 
 The **Go** implementation is called **Geth** (the old english third person singular conjugation of “to go”. Quite appropriate given geth is written in Go). Geth has been audited for security and will be the future basis for the end user facing **Mist Browser**, so if you have experience on web development and are interested in building frontend for html dapps, you should experiment with Geth.
 

--- a/views/content/crowdsale.md
+++ b/views/content/crowdsale.md
@@ -109,7 +109,7 @@ You know the drill: if you are using the solC compiler,[remove line breaks](http
         }
     });
 
-**If you are using the _online compiler_ Copy the contract code to the [online solidity compiler](https://chriseth.github.io/cpp-ethereum/), and then grab the content of the box labeled **Geth Deploy**. Since you have already set the parameters, you don't need to change anything to that text, simply paste the resulting text on your geth window.**
+**If you are using the _online compiler_ Copy the contract code to the [online solidity compiler](https://chriseth.github.io/browser-solidity/), and then grab the content of the box labeled **Geth Deploy**. Since you have already set the parameters, you don't need to change anything to that text, simply paste the resulting text on your geth window.**
 
 Wait up to thirty seconds and you'll see a message like this:
 

--- a/views/content/dao.md
+++ b/views/content/dao.md
@@ -153,7 +153,7 @@ With these default parameters anyone with any tokens can make a proposal on how 
         }
     });
 
-**If you are using the _online compiler_ Copy the contract code to the [online solidity compiler](https://chriseth.github.io/cpp-ethereum/), and then grab the content of the box labeled **Geth Deploy**. Since you have already set the parameters, you don't need to change anything to that text, simply paste the resulting text on your geth window.**
+**If you are using the _online compiler_ Copy the contract code to the [online solidity compiler](https://chriseth.github.io/browser-solidity/), and then grab the content of the box labeled **Geth Deploy**. Since you have already set the parameters, you don't need to change anything to that text, simply paste the resulting text on your geth window.**
 
 Wait a minute until the miners pick it up. It will cost you about 850k Gas. Once that is picked up, it's time to instantiate it and set it up, by pointing it to the correct address of the token contract you created previously. 
 

--- a/views/content/ether.md
+++ b/views/content/ether.md
@@ -6,7 +6,7 @@ Ether is a necessary element -- a fuel -- for operating the distributed applicat
 
 Feeling comfortable? Time to get some ether!
 
-**If you just want to test the technology, you probably don't need real ether. [Just deploy a private test net](../cli/) and you will be able get free test ether by mining**.
+**If you just want to test the technology, you probably don't need real ether. [Just deploy a private test net](../cli) and you will be able get free test ether by mining**.
 
 
 ## Get Ether
@@ -19,7 +19,7 @@ This process is usually called **_mining_** in the crypto-currency lingo.
 
 #### CPU MINING
 
-If you are on a [private network](../geth) (and if you just want to test the technology for free, you should) then any normal computer with a normal CPU will be able to run the network and earn test ether (ether that is only redeemable on the test network where it was generated) through mining. This is a the best choice for small scale network or testing privately, as it's less resource intensive. On the real (or live test) network a normal desktop (or laptop) computer might take a very long time to succesfully mine a block and receive ether.
+If you are on a [private network](../cli) (and if you just want to test the technology for free, you should) then any normal computer with a normal CPU will be able to run the network and earn test ether (ether that is only redeemable on the test network where it was generated) through mining. This is a the best choice for small scale network or testing privately, as it's less resource intensive. On the real (or live test) network a normal desktop (or laptop) computer might take a very long time to succesfully mine a block and receive ether.
 
 Before you do any mining, you need to set which address will receive your earnings (called "etherbase"). You only need to this once. Here's how to set your etherbase and then start mining:
 
@@ -67,7 +67,7 @@ There are currently two options for GPU mining in Geth available. You can read a
 
 * **C++ Etherminer**. This is a version for the pro miners. To install it, follow the guide to [install the whole C++ ethereum code](https://github.com/ethereum/cpp-ethereum/wiki/Installing-clients). 
 
-* **Go experimental GPU branch**. It's experimental so you need to build go from source to get it. This version is focused for hobbyists and developers. To install it, [clone geth from source](https://github.com/ethereum/go-ethereum/wiki/Installation-Instructions-for-Ubuntu) and then switch to the [GPU Miner branch](https://github.com/ethereum/go-ethereum/tree/gpuminer)
+* **Go experimental GPU branch**. It's experimental so you need to build go from source to get it. This version is focused for hobbyists and developers. To install it, [clone geth from source](https://github.com/ethereum/go-ethereum/wiki/Installation-Instructions-for-Ubuntu) and then switch to the [GPU Miner branch](https://github.com/ethereum/go-ethereum/tree/gpu_miner)
 
 
 Both setups are explain in further detail in the [Frontier reference](http://guide.ethereum.org/mining.html)
@@ -75,7 +75,7 @@ Both setups are explain in further detail in the [Frontier reference](http://gui
 #### More information on Mining
 
 * Frontier's proof of work algorithm does not make use of Scrypt or Sha256, instead, it leverages [EtHash](https://github.com/ethereum/wiki/wiki/Ethash), a Hashimoto / Dagger hybrid. You can read all about the theory behind this and its design in the [Frontier gitBook, mining chapter](http://guide.ethereum.org/mining.html). Note that for Serenity (a future release, a major milestone on the Ethereum development roadmap) we are planning to switch to Proof of Stake (PoS).
-
+geth
 * The Ethash proof of work algorithm is memory hard, you'll need at least 1+GB of RAM on each GPU. I say 1+ because the DAG, which is the set of data that's being pushed in and out of the GPU to make parallelisation costly, will start at 1GB and will continue growing indefinitely. 2GB should be a good approximation of what's needed to continue mining throughout the year.
 
 * Mining prowess roughly scales proportionally to [memory bandwidth](https://en.wikipedia.org/wiki/AMD_Radeon_Rx_200_series#Chipset_table). As our implementation is written in OpenCL, AMD GPUs will be 'faster' than similarly priced NVIDIA GPUs. Empirical evidence has already confirmed this, with R9 290x regularly topping benchmarks. 

--- a/views/content/ether.md
+++ b/views/content/ether.md
@@ -75,7 +75,7 @@ Both setups are explain in further detail in the [Frontier reference](http://gui
 #### More information on Mining
 
 * Frontier's proof of work algorithm does not make use of Scrypt or Sha256, instead, it leverages [EtHash](https://github.com/ethereum/wiki/wiki/Ethash), a Hashimoto / Dagger hybrid. You can read all about the theory behind this and its design in the [Frontier gitBook, mining chapter](http://guide.ethereum.org/mining.html). Note that for Serenity (a future release, a major milestone on the Ethereum development roadmap) we are planning to switch to Proof of Stake (PoS).
-geth
+
 * The Ethash proof of work algorithm is memory hard, you'll need at least 1+GB of RAM on each GPU. I say 1+ because the DAG, which is the set of data that's being pushed in and out of the GPU to make parallelisation costly, will start at 1GB and will continue growing indefinitely. 2GB should be a good approximation of what's needed to continue mining throughout the year.
 
 * Mining prowess roughly scales proportionally to [memory bandwidth](https://en.wikipedia.org/wiki/AMD_Radeon_Rx_200_series#Chipset_table). As our implementation is written in OpenCL, AMD GPUs will be 'faster' than similarly priced NVIDIA GPUs. Empirical evidence has already confirmed this, with R9 290x regularly topping benchmarks. 

--- a/views/content/greeter.md
+++ b/views/content/greeter.md
@@ -102,7 +102,7 @@ If you have the SolC Solidity Compiler installed,  you need now reformat by remo
 
 #### Linking your compiler in Geth
 
-Now [go back to the console](../geth) and type this command to install solC, replacing _path/to/solc_ to the path that you got on the last command you did:
+Now [go back to the console](../cli) and type this command to install solC, replacing _path/to/solc_ to the path that you got on the last command you did:
 
     admin.setSolc("path/to/solc")
 
@@ -143,7 +143,7 @@ You have now compiled your code. Now you need to get it ready for deployment, th
 
 #### Using the online compiler
 
-If you don't have solC installed, you can simply use the online compiler. Copy the source code above to the [online solidity compiler](https://chriseth.github.io/cpp-ethereum/) and then your compiled code should appear on the left pane. Copy the code on the box labeled **Geth deploy** to a text file. Now change the first line to your greeting:
+If you don't have solC installed, you can simply use the online compiler. Copy the source code above to the [online solidity compiler](https://chriseth.github.io/browser-solidity/) and then your compiled code should appear on the left pane. Copy the code on the box labeled **Geth deploy** to a text file. Now change the first line to your greeting:
 
     var _greeting = "Hello World!"
  
@@ -151,7 +151,7 @@ Now you can paste the resulting text on your geth window. Wait up to thirty seco
 
     Contract mined! address: 0xdaa24d02bad7e9d6a80106db164bad9399a0423e 
 
-You will probably be asked for the password you picked in the beginning, because you need to pay for the gas costs to deploying your contract. This contract is estimated to need 172 thousand gas to deploy (according to the [online solidity compiler](https://chriseth.github.io/cpp-ethereum/)), at the time of writing, gas on the test net is priced at 1 to 10 microethers per unit of gas (nicknamed "szabo" = 1 followed by 12 zeroes in wei). To know the latest price in ether all you can see the [latest gas prices at the network stats page](https://stats.ethdev.com) and multiply both terms. 
+You will probably be asked for the password you picked in the beginning, because you need to pay for the gas costs to deploying your contract. This contract is estimated to need 172 thousand gas to deploy (according to the [online solidity compiler](https://chriseth.github.io/browser-solidity/)), at the time of writing, gas on the test net is priced at 1 to 10 microethers per unit of gas (nicknamed "szabo" = 1 followed by 12 zeroes in wei). To know the latest price in ether all you can see the [latest gas prices at the network stats page](https://stats.ethdev.com) and multiply both terms. 
 
 **Notice that the cost is not paid to the [ethereum developers](../foundation), instead it goes to the _Miners_, those peers whose computers are working to find new blocks and keep the network secure. Gas price is set by the market of the current supply and demand of computation. If the gas prices are too high, you can become a miner and lower your asking price.**
 

--- a/views/content/token.md
+++ b/views/content/token.md
@@ -68,7 +68,7 @@ Now let’s set up the contract, just like we did in the previous section. Chang
 
 #### Online Compiler
 
-**If you don't have solC installed, you can simply use the online compiler.** Copy the contract code to the [online solidity compiler](https://chriseth.github.io/cpp-ethereum/), if there are no errors on the contract you should see a text box labeled **Geth Deploy**. Copy the content to a text file so you can change the first line to set the initial supply, like this:  
+**If you don't have solC installed, you can simply use the online compiler.** Copy the contract code to the [online solidity compiler](https://chriseth.github.io/browser-solidity/), if there are no errors on the contract you should see a text box labeled **Geth Deploy**. Copy the content to a text file so you can change the first line to set the initial supply, like this:  
 
     var supply = 10000;
 

--- a/views/mixins/recipes.jade
+++ b/views/mixins/recipes.jade
@@ -12,7 +12,7 @@ mixin gethRecipe(header)
 
   p Frontier is focused on command line tools. You can use them to send ether (the network’s internal fuel) to someone else, load and execute contracts, import your pre-sale wallet or make your computer into a supporting node and earn ether.
 
-  a(href="cli").button Install the Command line tools
+  a(href="/cli").button Install the Command line tools
 
   div.recipe
     h4 You'll need:
@@ -45,7 +45,7 @@ mixin etherRecipe(header)
   
   p You can also get some from a friend or purchase it online.
   
-  a(href="../ether").button Get Ether
+  a(href="/ether").button Get Ether
   
   div.recipe
     h4 You'll need:
@@ -53,7 +53,7 @@ mixin etherRecipe(header)
       li 
         input(type="checkbox") 
         | Any of the 
-        a(href="#install-geth") Command Line Tools  
+        a(href="/#install-geth") Command Line Tools  
       li 
         input(type="checkbox") 
         |  One of these:
@@ -83,21 +83,21 @@ mixin greeterRecipe(header)
 
   p The greeter is a very simple contract that greets “Hello World” when poked. If you have never created any contracts in Ethereum before, this is where you should start.
 
-  a(href="greeter").button Summon the Greeter 
+  a(href="/greeter").button Summon the Greeter 
 
   div.recipe
     h4 You'll need:
     ul
       li 
         input(type="checkbox") 
-        a(href="#install-geth") Geth 
+        a(href="/#install-geth") Geth 
       li 
         input(type="checkbox") 
         |  Desire to learn new things  
       li 
         input(type="checkbox") 
         |  0.001 
-        a(href="#get-ether") ether 
+        a(href="/#get-ether") ether 
         | (approximately)
 
 mixin tokenRecipe(header)
@@ -113,21 +113,21 @@ mixin tokenRecipe(header)
 
   p The total amount of tokens in circulation can be set to a simple fixed amount, or fluctuate based on any programmed ruleset.
 
-  a(href="token").button Issue your token 
+  a(href="/token").button Issue your token 
 
   div.recipe
     h4 You'll need:
     ul
       li 
         input(type="checkbox") 
-        a(href="#install-geth") Geth 
+        a(href="/#install-geth") Geth 
       li 
         input(type="checkbox") 
         |  Very basic programming skills 
       li 
         input(type="checkbox") 
         |  0.002  
-        a(href="#get-ether") ether 
+        a(href="/#get-ether") ether 
         | (approximatelly)
       li 
         input(type="checkbox") 
@@ -149,26 +149,26 @@ mixin crowdsaleRecipe(header)
 
   p You can even use the token you created earlier to keep track of the distribution of rewards.
 
-  a(href="crowdsale").button Kickstart your project 
+  a(href="/crowdsale").button Kickstart your project 
 
   div.recipe
     h4 You'll need:
     ul
       li 
         input(type="checkbox") 
-        a(href="#install-geth") Geth 
+        a(href="/#install-geth") Geth 
       li 
         input(type="checkbox") 
         | Basic programming skills 
       li 
         input(type="checkbox") 
         | 0.004  
-        a(href="#get-ether") ether 
+        a(href="/#get-ether") ether 
         | (approximatelly)
       li 
         input(type="checkbox") 
         | An Ethereum-based 
-        a(href="#crypto-currency") digital token 
+        a(href="/#crypto-currency") digital token 
         | (to track rewards)
       li 
         input(type="checkbox") 
@@ -189,30 +189,30 @@ mixin daoRecipe(header)
 
   p One of the many advantages of having a robot run your organization, is that it is immune to any outside influence as it’s guaranteed to execute only what it was programmed to. And because the Ethereum network is decentralized, you'll be able to provide services with an 100% uptime guarantee. 
 
-  a(href="dao").button Start your organization 
+  a(href="/dao").button Start your organization 
 
   div.recipe
     h4 You'll need:
     ul
       li 
         input(type="checkbox") 
-        a(href="#install-geth") Geth 
+        a(href="/#install-geth") Geth 
       li 
         input(type="checkbox") 
         | Basic programming skills 
       li 
         input(type="checkbox") 
         | 0.008  
-        a(href="#get-ether") ether 
+        a(href="/#get-ether") ether 
         | (approximatelly) to create the contract 
       li 
         input(type="checkbox") 
         | Ethereum-based 
-        a(href="#crypto-currency") digital token  
+        a(href="/#crypto-currency") digital token  
         | (voting right)
       li 
         input(type="checkbox") 
-        a(href="#crowdsale") Any amount of funds
+        a(href="/#crowdsale") Any amount of funds
       li 
         input(type="checkbox") 
         | Ideas on where to invest these funds


### PR DESCRIPTION
A few links were dead, so I went through and cleaned up any ones that seemed stale.

Also, some of the jade recipes were href'ing to relative anchors. The anchors links would only work on the [main page](https://www.ethereum.org/), and not when viewed on sub pages on [Greeter](https://www.ethereum.org/greeter), or [Ether](https://www.ethereum.org/ether).  I changed these links to absolute anchors so the links work both on the index page, as well as the full sub-pages (/cli, /ether, /greeter, etc.)