### PR TITLE
Default option in install script with wrong uppercase order

### DIFF
--- a/bin/install-go.sh
+++ b/bin/install-go.sh
@@ -95,7 +95,7 @@ function run_installer()
 	function wait_for_user() {
 		while :
 		do
-			read -p "${blue}==>${reset} $1 (Y/n) " imp
+			read -p "${blue}==>${reset} $1 (y/N) " imp
 			case $imp in
 				[yY] ) echo; break ;;
 				* ) abortInstall "${red}==>${reset} Process stopped by user. To resume the install run the one-liner command again." ;;


### PR DESCRIPTION
Trying to install with:

    bash <(curl https://install-geth.ethereum.org -L)

shows a question where the default option is incorrectly uppercased:

    ...
    I understand, I want to install Geth (ethereum CLI) (Y/n)      

    ==> Installation failed
    ==> Process stopped by user. To resume the install run the one-liner command again.

Pressing only Enter (without entering any option) aborts the installation. Even when Yes is displayed as default.

**The default option is n (for no) and it should be uppercased instead of Y.**
