### PR TITLE
web3. before eth.getBalance

### DIFF
--- a/views/content/ether.md
+++ b/views/content/ether.md
@@ -43,7 +43,7 @@ If you have successfully mined a block you will see a message like this among th
  
 To check your earnings, you can display your balance with:
  
-    web3.fromWei(eth.getBalance(web3.eth.accounts[0]), "ether")
+    web3.fromWei(web3.eth.getBalance(web3.eth.accounts[0]), "ether")
 
 #### GPU MINING
 


### PR DESCRIPTION
Otherwise it returns

> web3.fromWei(eth.getBalance(web3.eth.accounts[0]), "ether")
(shell):1: ReferenceError: eth is not defined
web3.fromWei(eth.getBalance(web3.eth.accounts[0]), "ether")
             ^
ReferenceError: eth is not defined
    at (shell):1:14
Error: Uncaught ReferenceError: eth is not defined