### PR TITLE
Make eth installation instructions clearer

### DIFF
--- a/views/content/cli.md
+++ b/views/content/cli.md
@@ -24,7 +24,7 @@ The **C++** implementation is simply called **Eth**. It performs slightly faster
 
 ### Install: Mac and Linux
 
-Paste the above one-liner in your terminal for an automated install script. This script will detect your OS and will attempt to install Eth:
+Paste the one-liner below into your terminal for an automated install script. This script will detect your OS and will attempt to install Eth:
 
     bash <(curl https://install-eth.ethereum.org -L)
 

--- a/views/content/ether.md
+++ b/views/content/ether.md
@@ -132,7 +132,7 @@ Ether sent to your account should show up almost immediately, transactions being
 
 ## Sending your first transaction
 
-**ATTENTION: Ethereum addresses don't have, yet, built-in checks on them. That means that if you mistype an address, your ether will be lost forever, without a secondary confirmation window. If you are moving a significang amount, start with smaller quantities that you can afford to lose, until you feel confortable enough.**
+**ATTENTION: Ethereum addresses don't have, yet, built-in checks on them. That means that if you mistype an address, your ether will be lost forever, without a secondary confirmation window. If you are moving a significant amount, start with smaller quantities that you can afford to lose, until you feel confortable enough.**
 
 There are two types of accounts in Ethereum: *normal accounts*, holding ether that can only be moved with a private key and *contracts*, which hold ether only controlled by their own internal code. In this section we focus on the former. The remainder of this guide will be dedicated to the latter.
 


### PR DESCRIPTION
The instructions referenced a code block as being "above" when the code block
was below the text.